### PR TITLE
Remove python constraints from libsvs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 
-{% set cf_buildnumber = "0" %}
+{% set cf_buildnumber = "1" %}
 {% set py_tag = "py" + PY_VER|replace('.','') %}
 {% set intel_ch = "https://software.repos.intel.com/python/conda" %}
 
@@ -136,13 +136,10 @@ outputs:
         - $RPATH/libm.so.6
         - $RPATH/libdl.so.2
         - $RPATH/libc.so.6
-      ignore_run_exports:
-        - python
     requirements:
       host:
         - conda-package-handling
       run:
-        - python >=3.10
         - libstdcxx
         - libgcc
     about:
@@ -180,14 +177,12 @@ outputs:
         - $RPATH/libdl.so.2
         - $RPATH/libc.so.6
       ignore_run_exports:
-        - python
         - libgomp
         - _openmp_mutex
     requirements:
       host:
         - conda-package-handling
       run:
-        - python >=3.10
         - libstdcxx
         - libgcc
         - libgomp


### PR DESCRIPTION
This PR removes all python-related constraints from the libsvs packages, as the current setup results in availability only in py3.14

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
