### PR TITLE
Add libsvs-runtime checks

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -209,7 +209,7 @@ outputs:
         - |
           cat > CMakeLists.txt << 'EOF'
           cmake_minimum_required(VERSION 3.24)
-          project(test_svs_runtime)
+          project(test_svs_runtime LANGUAGES NONE)
           find_package(svs_runtime REQUIRED)
           message(STATUS "Successfully found svs_runtime package")
           EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 
-{% set cf_buildnumber = "1" %}
+{% set cf_buildnumber = "2" %}
 {% set py_tag = "py" + PY_VER|replace('.','') %}
 {% set intel_ch = "https://software.repos.intel.com/python/conda" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -198,7 +198,6 @@ outputs:
       doc_url: https://intel.github.io/ScalableVectorSearch/index.html
     test:
       requires:
-        - python 3.13.* # Ensures installability on pythons older than most recent, this version can be incremented over time
         - cmake 3.*
         - make
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -197,9 +197,24 @@ outputs:
       dev_url: https://github.com/intel/ScalableVectorSearch
       doc_url: https://intel.github.io/ScalableVectorSearch/index.html
     test:
+      requires:
+        - python 3.13.* # Ensures installability on pythons older than most recent, this version can be incremented over time
+        - cmake 3.*
+        - make
       commands:
+        # Validate file installation
         - test -f $PREFIX/lib/libsvs_runtime.so
         - test -f $PREFIX/include/svs/runtime/api_defs.h
+        # Validate CMake find_package(svs_runtime) works
+        - |
+          cat > CMakeLists.txt << 'EOF'
+          cmake_minimum_required(VERSION 3.24)
+          project(test_svs_runtime)
+          find_package(svs_runtime REQUIRED)
+          message(STATUS "Successfully found svs_runtime package")
+          EOF
+        - cmake . -DCMAKE_PREFIX_PATH=$PREFIX
+        - test -f CMakeCache.txt
 
 # pleases the linter
 about:

--- a/recipe/repack_libsvs.sh
+++ b/recipe/repack_libsvs.sh
@@ -20,6 +20,12 @@ if [ -d "$root/lib" ]; then
   cp -a "$root/lib"/*.a "$PREFIX/lib/" 2>/dev/null || true
 fi
 
+# Copy CMake config files if they exist
+if [ -d "$root/lib/cmake" ]; then
+  mkdir -p "$PREFIX/lib/cmake"
+  cp -a "$root/lib/cmake"/* "$PREFIX/lib/cmake/"
+fi
+
 # Copy headers if they exist
 if [ -d "$root/include" ]; then
   mkdir -p "$PREFIX/include"

--- a/recipe/repack_libsvs_runtime.sh
+++ b/recipe/repack_libsvs_runtime.sh
@@ -20,6 +20,12 @@ if [ -d "$root/lib" ]; then
   cp -a "$root/lib"/*.a "$PREFIX/lib/" 2>/dev/null || true
 fi
 
+# Copy CMake config files if they exist
+if [ -d "$root/lib/cmake" ]; then
+  mkdir -p "$PREFIX/lib/cmake"
+  cp -a "$root/lib/cmake"/* "$PREFIX/lib/cmake/"
+fi
+
 # Copy headers if they exist
 if [ -d "$root/include" ]; then
   mkdir -p "$PREFIX/include"


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Adds some simple checks to validate libsvs-runtime can be installed on python 3.13 (non latest) environment and also can be found via cmake find_package()

Fixes issue where it could not have been found previously by copying lib/cmake contents from intel channel package


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
